### PR TITLE
Changed most return types from int to ld_status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories(/usr/local/lib/include)
 
 set(LD_LIBS websockets jansson curl crypto)
 
-set(LD_SOURCE lib/libdiscord.c lib/libdiscord.h lib/REST.h lib/REST.c lib/log.c lib/log.h lib/json.c lib/json.h lib/utils.c lib/utils.h)
+set(LD_SOURCE lib/libdiscord.c lib/libdiscord.h lib/REST.h lib/REST.c lib/log.c lib/log.h lib/json.c lib/json.h lib/utils.c lib/utils.h lib/status.h)
 add_library(discord SHARED ${LD_SOURCE})
 
 target_link_libraries(discord ${LD_LIBS})

--- a/Doxyfile
+++ b/Doxyfile
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md doc/BUILDING.md lib/
+INPUT                  = README.md CODING_NOTES.md doc/BUILDING.md lib/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/lib/REST.h
+++ b/lib/REST.h
@@ -10,6 +10,7 @@
 #include <curl/curl.h>
 
 //#include <libdiscord.h>
+#include "status.h"
 #include "json.h"
 
 #ifndef LD_SNOWFLAKE

--- a/lib/libdiscord.h
+++ b/lib/libdiscord.h
@@ -8,6 +8,7 @@
 #include <jansson.h>
 
 #include "libdiscord_config.h"
+
 #include "log.h"
 #include "json.h"
 
@@ -286,7 +287,7 @@ struct ld_json_identify;
  * 
  * @return int Success code (0 success, 1 error)
  */
-int ld_init_context_info(struct ld_context_info *info);
+ld_status ld_init_context_info(struct ld_context_info *info);
 
 /**
  * @brief Initializes an ld_context struct using a given ld_context_info
@@ -296,7 +297,7 @@ int ld_init_context_info(struct ld_context_info *info);
  * 
  * @return int Status code
  */
-int ld_init_context(struct ld_context_info *info, struct ld_context *context);
+ld_status ld_init_context(struct ld_context_info *info, struct ld_context *context);
 
 /**
  * @brief Frees the members of a given ld_context struct, then destroys the struct
@@ -317,7 +318,7 @@ void ld_cleanup_context(struct ld_context *context);
  * @n 2: CURL error
  * @n 3: jansson (JSON parsing) error
  */
-int _ld_get_gateway_bot(struct ld_context *context);
+ld_status _ld_get_gateway_bot(struct ld_context *context);
 
 /**
  * @brief curl callback function used to read data returned from HTTP request
@@ -345,7 +346,7 @@ size_t _ld_curl_response_string(void *contents, size_t size, size_t nmemb, void 
  * @n 2: CURL error
  * @n 3: jansson (JSON parsing) error
  */
-int _ld_get_gateway(struct ld_context *context);
+ld_status _ld_get_gateway(struct ld_context *context);
 
 /**
  * @brief CURL callback function used to (currently) print out HTTP headers line by line for /gateway and /gateway/bot
@@ -365,7 +366,7 @@ size_t ld_curl_header_parser(char *buffer, size_t size, size_t nitems, void *use
  * @param identify Pointer to ld_json_identify struct, from which to take identify information
  * @return int Status code
  */
-int ld_set_identify(struct ld_context *context, struct ld_json_identify *identify);
+ld_status ld_set_identify(struct ld_context *context, struct ld_json_identify *identify);
 
 /**
  * @brief Connects to Discord with a given ld_context struct
@@ -373,7 +374,7 @@ int ld_set_identify(struct ld_context *context, struct ld_json_identify *identif
  * @param context Pointer to an ld_context struct
  * @return int Status code
  */
-int ld_connect(struct ld_context *context);
+ld_status ld_connect(struct ld_context *context);
 
 /**
  * @brief Checks services pending HTTP and websocket requests
@@ -386,7 +387,7 @@ int ld_connect(struct ld_context *context);
  * @n 0: OK
  * @n 1: websocket ringbuffer error
  */
-int ld_service(struct ld_context *context, int timeout);
+ld_status ld_service(struct ld_context *context, int timeout);
 
 /**
  * @brief Starts a fresh gateway connection
@@ -400,7 +401,7 @@ int ld_service(struct ld_context *context, int timeout);
  * 
  * @return int Status code. 0 on success.
  */
-int ld_gateway_connect(struct ld_context *context);
+ld_status ld_gateway_connect(struct ld_context *context);
 
 /**
  * @brief picks out interesting callback reasons (like receive and writeable) and does stuff 
@@ -414,7 +415,7 @@ int ld_gateway_connect(struct ld_context *context);
  * 
  * @return int 
  */
-int ld_lws_callback(struct lws *wsi, enum lws_callback_reasons reason,
+ld_status ld_lws_callback(struct lws *wsi, enum lws_callback_reasons reason,
                     void *user, void *in, size_t len);
 
 /**
@@ -424,7 +425,7 @@ int ld_lws_callback(struct lws *wsi, enum lws_callback_reasons reason,
  * @param identify 
  * @return int 
  */
-int ld_set_identify(struct ld_context *context, struct ld_json_identify *identify);
+ld_status ld_set_identify(struct ld_context *context, struct ld_json_identify *identify);
 
 /**
  * @brief 
@@ -432,7 +433,7 @@ int ld_set_identify(struct ld_context *context, struct ld_json_identify *identif
  * @param identify 
  * @return int 
  */
-int ld_cleanup_identify(struct ld_json_identify *identify);
+ld_status ld_cleanup_identify(struct ld_json_identify *identify);
 
 /**
  * @brief 
@@ -443,7 +444,7 @@ int ld_cleanup_identify(struct ld_json_identify *identify);
  * 
  * @return int 
  */
-int ld_gateway_payload_parser(struct ld_context *context, char *in, size_t len);
+ld_status ld_gateway_payload_parser(struct ld_context *context, char *in, size_t len);
 
 /**
  * @brief callback for parsing READY dispatches, saves session_id for resuming
@@ -453,7 +454,7 @@ int ld_gateway_payload_parser(struct ld_context *context, char *in, size_t len);
  * 
  * @return int Status code
  */
-int ld_dispatch_ready(struct ld_context *context, json_t *data);
+ld_status ld_dispatch_ready(struct ld_context *context, json_t *data);
 
 /**
  * @brief 
@@ -466,7 +467,7 @@ int ld_dispatch_ready(struct ld_context *context, json_t *data);
  * @n 0: success
  * @n 1: jansson (JSON parsing) error
  */
-int ld_gateway_dispatch_parser(struct ld_context *context, json_t *type, json_t *data);
+ld_status ld_gateway_dispatch_parser(struct ld_context *context, json_t *type, json_t *data);
 
 /**
  * @brief Queues a heartbeat payload into the websocket tx ringbuffer
@@ -474,7 +475,7 @@ int ld_gateway_dispatch_parser(struct ld_context *context, json_t *type, json_t 
  * @param context Pointer to an ld_context for which to queue the payload
  * @return int Status code
  */
-int ld_gateway_queue_heartbeat(struct ld_context *context);
+ld_status ld_gateway_queue_heartbeat(struct ld_context *context);
 
 /**
  * @brief Gets the operating system name

--- a/lib/log.h
+++ b/lib/log.h
@@ -12,7 +12,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 //#include "libdiscord.h"
+#include "status.h"
 
 /*
  * logging levels are bitfields set in a ld context

--- a/lib/status.h
+++ b/lib/status.h
@@ -1,0 +1,36 @@
+/** @file */ 
+
+#ifndef LIBDISCORD_STATUS_H
+#define LIBDISCORD_STATUS_H
+
+/**
+ * @brief Status codes returned from libdiscord functions
+ * @description
+ * 0 to 99: OK, error, and memory issues
+ * 100 to 199: generic connection issues
+ * 200 to 299: libwebsocket issues
+ * 300 to 399: JSON parsing issues (jansson)
+ * 900 to 999: Discord issues (tokens, permissions, etc.)
+ */
+ typedef enum ld_status_enum {
+     LDS_OK = 0, ///< success
+     LDS_ERROR = 1, ///< generic error
+     LDS_MEMORY_ERR = 2, ///< generic memory error
+     LDS_ALLOC_ERR = 3, ///< error allocating something (usually a struct)
+     LDS_CONNECTION_ERR = 100, ///< connection error
+     LDS_CURL_ERR = 101, ///< CURL error
+     LDS_WEBSOCKET_RINGBUFFER_ERR = 200, ///< generic ringbuffer error
+     LDS_WEBSOCKET_RINGBUFFER_FULL_ERR = 201, ///< websocket: ringbuffer full
+     LDS_WEBSOCKET_CANTFIT_PAYLOAD_ERR = 210, ///< websocket: can't fit new payload into ringbuffer error
+     LDS_WEBSOCKET_CANTFIT_HEARTBEAT_ERR = 211, ///< websocket: can't fit heartbeat into ringbuffer error
+     LDS_WEBSOCKET_HEARTBEAT_ACKNOWLEDEGEMENT_MISSED = 220, ///< websocket: heartbeat ack missed
+     LDS_JSON_ERR = 300, ///< generic JSON error
+     LDS_JSON_DECODING_ERR = 301, ///< JSON decoding error
+     LDS_JSON_ENCODING_ERR = 302, ///< JSON encoding error
+     LDS_JSON_CANTFINDKEY_ERR = 310, ///< JSON no such key found error
+     LDS_JSON_CANTFINDVALUE_ERR = 311, ///< JSON value expected, none found error
+     LDS_JSON_GATEWAY_DISPATCH_TYPE_ERR = 320, /// JSON gateway dispatch type not resolved error
+     LDS_TOKEN_MISSING_ERR = 900 ///< no token specified for bot
+ } ld_status;
+
+ #endif //LIBDISCORD_STATUS_H


### PR DESCRIPTION
Created an enum in status.h with return codes for most of libdiscord's functions

Rationale: all of the return codes had different numbers between different functions, even in the same files. This effectively made the values meaningless magic numbers.

Solution: use the ld_status typedef instead, and always compare with the corresponding LDS_* cases rather than raw numbers.

Benefits: we can add more return types, most representing error codes, in the enum to add more granularity to what to check for. This also makes it easier to write an Objective-C wrapper.