### PR TITLE
Fixing a bug that causes errors on build attempts

### DIFF
--- a/lib/json.h
+++ b/lib/json.h
@@ -2,6 +2,7 @@
 
 #ifndef LIBDISCORD_JSON_H
 #define LIBDISCORD_JSON_H
+#define _GNU_SOURCE 1
 
 #include <libdiscord.h>
 #include <jansson.h>


### PR DESCRIPTION
On the libdiscord guild, someone has had issues with building the library. `make` gave him the following error:  
```
/home/nat/Devel/git-repos/libdiscord/lib/json.c: In function ‘ld_json_read_timestamp’:
/home/nat/Devel/git-repos/libdiscord/lib/json.c:423:12: error: implicit declaration of function ‘getdate’; did you mean ‘setstate’? [-Werror=implicit-function-declaration]
     time = getdate(timestamp);
            ^~~~~~~
            setstate
/home/nat/Devel/git-repos/libdiscord/lib/json.c:423:10: error: assignment to ‘struct tm *’ from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion]
     time = getdate(timestamp);
          ^
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/discord.dir/build.make:102: CMakeFiles/discord.dir/lib/json.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/discord.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

After doing some research, I noticed that C complains about the `getdate` function provided by the `time.h` header unless the code has a macro definition `#define _GNU_SOURCE 1`.

This pull request adds the missing macro which fixed the problem for me.