### PR TITLE
Ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+build/
 # Created by https://www.gitignore.io/api/clion
 
 ### CLion ###


### PR DESCRIPTION
Docs mention creating `./build` dir, that doesn't already exist.
Would be nice for `git status` to not report the build dir as part of the repository if nothing within is meant to be committed :)